### PR TITLE
git-pr-release を CI で走らせる

### DIFF
--- a/.github/workflows/git-pr-release.yml
+++ b/.github/workflows/git-pr-release.yml
@@ -1,0 +1,22 @@
+name: Create Release Pull Request
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  git-pr-release:
+    name: git-pr-release
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5.1
+      - name: Install git-pr-release
+        run: gem install --no-document git-pr-release
+      - name: Run git-pr-release
+        env:
+          GIT_PR_RELEASE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_PR_RELEASE_BRANCH_PRODUCTION: main
+          GIT_PR_RELEASE_BRANCH_STAGING: develop
+        run: git-pr-release --no-fetch


### PR DESCRIPTION
# 概要

develop にマージがあったときに、
git-pr-release を GitHub Actions により走らせる
