### PR TITLE
continue-on-error: true

### DIFF
--- a/.github/workflows/git-pr-release.yml
+++ b/.github/workflows/git-pr-release.yml
@@ -20,3 +20,4 @@ jobs:
           GIT_PR_RELEASE_BRANCH_PRODUCTION: main
           GIT_PR_RELEASE_BRANCH_STAGING: develop
         run: git-pr-release --no-fetch
+        continue-on-error: true


### PR DESCRIPTION
# 概要

作るべきプルリクがないときにエラーを吐いてしまうので、
continue-on-error: true に
